### PR TITLE
Fix: Correções de build para docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install --force
 
-ENV NODE_ENV=${NODE_ENV}
-ENV NEXT_PUBLIC_SCHOOL_BACKEND=${NEXT_PUBLIC_SCHOOL_BACKEND}
-
-RUN echo "NODE_ENV=${NODE_ENV}" > .env.production
-RUN echo "NEXT_PUBLIC_SCHOOL_BACKEND=${NEXT_PUBLIC_SCHOOL_BACKEND}" >> .env.production
+COPY .env.production .env.production
 
 COPY . .
 
@@ -22,7 +18,6 @@ WORKDIR /app
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY package.json package-lock.json ./
-COPY --from=builder /app/.env.production ./.env.production
 
 RUN npm install --force --production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,12 @@ services:
     networks:
       - schoolnetwork
   schoolpostfront:
-    image: vitorpc4/schoolpostfront
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: schoolpostfront
     ports:
       - "3020:3020"
-    environment:
-      NODE_ENV: production
-      NEXT_PUBLIC_SCHOOL_BACKEND: http://localhost:3001
     depends_on:
       - db
       - app

--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,25 @@ git clone https://github.com/vitorpc4/schoolpostfront.git
 # Navegue até o diretório do projeto
 cd schoolpostfront
 
-# Modifique as variáveis de ambiente necessárias no arquivo Docker Compose.
+# Por limitações do nextjs em tratar variáveis de ambientes, será necessário criar um arquivo
+# .env.production no projeto.
 
-#suba os containers
+NODE_ENV=production
+NEXT_PUBLIC_SCHOOL_BACKEND=http://localhost:3001
 
-docker compose up -d
+#  O arquivo pode ser criado manualmente, ou executando os comandos abaixo para criação automática
+
+# Windows Powershel
+
+"NEXT_PUBLIC_SCHOOL_BACKEND=http://localhost:3001" | Out-File -FilePath .env.production -Force; "NODE_ENV=production" | Out-File -FilePath .env.production -Append
+
+# Unix (Linux Ou MacOs)
+
+echo -e "NEXT_PUBLIC_SCHOOL_BACKEND=http://localhost:3001\nNODE_ENV=production" > .env.production
+
+# suba os containers
+
+docker compose up -d --build
 ```
 
 - Atenção, durante caso você enfrente problemas com o build sugiro que seja feito o seguinte procedimentos


### PR DESCRIPTION
* Ajusta docker compose e Dockerfile
* Ajustado para evitar situações adversa durante a execução  do build do next.js
* Agora é necessário criar um .env.production que será utilizado pelo projeto do nextjs durante o build local